### PR TITLE
treewide: Modernize nix::sys::ptrace usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ homepage = "https://github.com/luser/spawn-ptrace"
 repository = "https://github.com/luser/spawn-ptrace"
 
 [dependencies]
-nix = "0.7.0"
+nix = "0.18"

--- a/tests/skeptic.rs
+++ b/tests/skeptic.rs
@@ -6,11 +6,19 @@ use std::process::Command;
 #[test]
 fn readme_test() {
     let rustdoc = Path::new("rustdoc").with_extension(EXE_EXTENSION);
-    let readme = Path::new(file!()).parent().unwrap().parent().unwrap().join("README.md");
+    let readme = Path::new(file!())
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("README.md");
     let exe = env::current_exe().unwrap();
     let depdir = exe.parent().unwrap();
     let outdir = depdir.parent().unwrap();
-    let extern_arg = format!("spawn_ptrace={}", outdir.join("libspawn_ptrace.rlib").to_string_lossy());
+    let extern_arg = format!(
+        "spawn_ptrace={}",
+        outdir.join("libspawn_ptrace.rlib").to_string_lossy()
+    );
     let mut cmd = Command::new(rustdoc);
     cmd.args(&["--verbose", "--test", "-L"])
         .arg(&outdir)
@@ -20,10 +28,13 @@ fn readme_test() {
         .arg(&extern_arg)
         .arg(&readme);
     println!("Running `{:?}`", cmd);
-    let result = cmd.spawn()
+    let result = cmd
+        .spawn()
         .expect("Failed to spawn process")
         .wait()
         .expect("Failed to run process");
-    assert!(result.success(), "Failed to run rustdoc tests on README.md!");
+    assert!(
+        result.success(),
+        "Failed to run rustdoc tests on README.md!"
+    );
 }
-


### PR DESCRIPTION
Hi there! Thanks for making this crate.

I was looking at using it on a research project that I'm working on, and I noticed that it was no longer compiling correctly. I've taken the liberty of bringing it up to date with the latest `nix` release and giving it a pass through `cargo fmt`. I confirmed locally that the tests still pass.

The external-facing API hasn't changed at all.

Please let me know if there's anything else I can do!